### PR TITLE
Add R-CMD-check GitHub Actions workflow

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,7 @@
 ^\.git$
 ^\.gitignore$
 ^\.github$
+^\.github/.*$
 ^\.claude$
 ^\.Rproj\.user$
 ^.*\.Rproj$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,50 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
   <!-- badges: start -->
-  [![R-CMD-check](https://github.com/tamminenlab/blaster/workflows/R-CMD-check/badge.svg)](https://github.com/tamminenlab/blaster/actions)
+  [![R-CMD-check](https://github.com/tamminenlab/blaster/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/tamminenlab/blaster/actions/workflows/R-CMD-check.yaml)
   [![CRAN status](https://www.r-pkg.org/badges/version/blaster)](https://CRAN.R-project.org/package=blaster)
   <!-- badges: end -->
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/R-CMD-check.yaml` — the standard [r-lib/actions](https://github.com/r-lib/actions) check-standard matrix (macOS, Windows, Ubuntu × devel / release / oldrel-1).
- Fix the broken R-CMD-check badge in [README.md](README.md) — it pointed to a workflow that didn't exist. Updated to the modern `/actions/workflows/<file>/badge.svg` URL that matches the new workflow filename.
- Add `.github/` to [.Rbuildignore](.Rbuildignore) so the workflow stays out of the CRAN source tarball.

## Why

The README has advertised an R-CMD-check badge for a while, but there was no corresponding workflow — so the badge was broken and nothing ran `R CMD check` on push. The absence of CI is part of why the `SystemRequirements: C++` issue that got the package archived on CRAN (2026-01-15, see [#7](https://github.com/tamminenlab/blaster/pull/7)) was never caught before submission. With this workflow, a future CRAN-incompatible change should fail CI before it can land.

## Test plan

- [ ] Merge to main
- [ ] Watch the first workflow run complete successfully across all 5 matrix configs at https://github.com/tamminenlab/blaster/actions
- [ ] Confirm the README badge renders green

🤖 Generated with [Claude Code](https://claude.com/claude-code)