### PR TITLE
Write blast() output to tempdir(), not getwd()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: blaster
 Type: Package
 Title: Native R Implementation of an Efficient BLAST-Like Algorithm
-Version: 1.0.8
-Date: 2026-04-21
+Version: 1.0.9
+Date: 2026-04-24
 Authors@R: c(person("Manu", "Tamminen",
              email = "mavatam@utu.fi",
              role = c("aut", "cre"),

--- a/R/blaster.R
+++ b/R/blaster.R
@@ -108,11 +108,11 @@ blast <- function(query,
                                  "TargetMatchEnd", "QueryMatchSeq",
                                  "TargetMatchSeq", "NumColumns", "NumMatches",
                                  "NumMismatches", "NumGaps", "Identity", "Alignment"))
-        filename <- paste0("blast_results-", Sys.time(), ".csv")
+        filename <- tempfile(pattern = "blast_results-", fileext = ".csv")
         write.csv(csv_file,
                   filename,
                   row.names = FALSE)
-        paste0(getwd(), "/", filename)
+        filename
     }
     else
         read.csv(tmp_file,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,18 +1,25 @@
 # Resubmission
 
-This is a resubmission of `blaster` after it was archived on CRAN on
-2026-01-15. The archival reason was an invalid `SystemRequirements: C++`
-specification in DESCRIPTION.
+This is a resubmission of `blaster` addressing CRAN reviewer feedback on
+version 1.0.8. The reviewer flagged that `blast(output_to_file = TRUE)`
+wrote its CSV result into the user's working directory, which is not
+allowed by CRAN policy.
 
-## Changes in this version (1.0.8)
+## Changes in this version (1.0.9)
 
-* Dropped the `SystemRequirements` field (C++11 is now the default R toolchain
-  and CRAN recommends not specifying it unless essential).
-* Regenerated `man/read_fasta.Rd` — the previous file had accidentally been
-  replaced with raw R source instead of Rd markup, producing a build warning.
-* Added `.Rbuildignore` to exclude `.git`, `.claude`, and other development
-  artifacts from the source tarball.
+* `blast(output_to_file = TRUE)` now writes the result CSV to `tempdir()`
+  via `tempfile()` instead of the current working directory, and returns
+  the tempfile path. No function writes to the user's home filespace.
 * Bumped version and date.
+
+## Prior (1.0.8) changes still included
+
+* Dropped the `SystemRequirements` field (C++11 is now the default R
+  toolchain and CRAN recommends not specifying it unless essential) —
+  this was the original reason the package was archived on 2026-01-15.
+* Regenerated `man/read_fasta.Rd` — the previous file had accidentally
+  been replaced with raw R source instead of Rd markup.
+* Added `.Rbuildignore` to exclude development artifacts from the tarball.
 
 ## R CMD check --as-cran
 


### PR DESCRIPTION
## Summary

Addresses CRAN reviewer feedback on the 1.0.8 resubmission:

> Please ensure that your functions do not write by default or in your examples/vignettes/tests in the user's home filespace (including the package directory and getwd()). This is not allowed by CRAN policies.

`blast(output_to_file = TRUE)` was writing `blast_results-<timestamp>.csv` into `getwd()`. Now it uses `tempfile(pattern = "blast_results-", fileext = ".csv")` and returns that path. No API change — the function still returns a string path to the written CSV.

Bump 1.0.8 → 1.0.9 and update [cran-comments.md](cran-comments.md) accordingly.

## Verification

`R CMD check --as-cran` locally: 0 errors, 0 warnings, 2 benign NOTEs (the "archived package / new submission" notice, and a local time-check failure).

## Test plan

- [ ] Merge to main
- [ ] `R CMD build .` from the main checkout
- [ ] Submit `blaster_1.0.9.tar.gz` via https://cran.r-project.org/submit.html, pasting [cran-comments.md](cran-comments.md) into the submission comment
- [ ] Reply to CRAN reviewer on the existing submission thread confirming the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)